### PR TITLE
Updated current version number in dependency statement to 2.0.0 to match...

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The code for this plugin has moved to a [subproject of the Grails Data](https://
 
 Edit `BuildConfig.groovy` and add the following dependency:
 
-    compile ":rest-client-builder:1.0.3"
+    compile ":rest-client-builder:2.0.0"
 
 ## Basic Usage
 


### PR DESCRIPTION
... current release and javadocs

The listed dependency (1.0.3) conflicts with the javadocs linked on the same page. Specifically, 1.0.3 doesn't support things like params on get() requests (which confused me for an hour!). Thanks!
